### PR TITLE
Scytal cipher rewritten

### DIFF
--- a/secretpy/__init__.py
+++ b/secretpy/__init__.py
@@ -9,7 +9,8 @@ from .ciphers import (
     ColumnarTransposition, FourSquare, Gronsfeld, Keyword,
     MyszkowskiTransposition, Nihilist, SimpleSubstitution,
     Playfair, Porta, Polybius, Rot13, Rot18, Rot47, Rot5,
-    ThreeSquare, Trifid, TwoSquare, Vigenere, Vic, Zigzag)
+    Scytale, ThreeSquare, Trifid, TwoSquare, Vigenere, Vic,
+    Zigzag)
 # import alphabets
 # from .cmdecorators import *
 
@@ -21,6 +22,6 @@ __all__ = [
     "Chao", "ColumnarTransposition", "FourSquare", "Gronsfeld",
     "Keyword", "MyszkowskiTransposition",
     "Nihilist", "SimpleSubstitution", "Playfair", "Porta", "Polybius",
-    "Rot13", "Rot18", "Rot47", "Rot5", "ThreeSquare",
+    "Rot13", "Rot18", "Rot47", "Rot5", "Scytale", "ThreeSquare",
     "Trifid", "TwoSquare", "Vigenere", "Vic", "Zigzag",
 ]

--- a/secretpy/ciphers/__init__.py
+++ b/secretpy/ciphers/__init__.py
@@ -25,6 +25,7 @@ from .rot13 import Rot13
 from .rot18 import Rot18
 from .rot47 import Rot47
 from .rot5 import Rot5
+from .scytale import Scytale
 from .three_square import ThreeSquare
 from .trifid import Trifid
 from .two_square import TwoSquare
@@ -38,6 +39,6 @@ __all__ = [
     "Chao", "ColumnarTransposition", "FourSquare", "Gronsfeld",
     "Keyword", "MyszkowskiTransposition",
     "Nihilist", "SimpleSubstitution", "Playfair", "Porta", "Polybius",
-    "Rot13", "Rot18", "Rot47", "Rot5", "ThreeSquare",
+    "Rot13", "Rot18", "Rot47", "Rot5", "Scytale", "ThreeSquare",
     "Trifid", "TwoSquare", "Vigenere", "Vic", "Zigzag",
 ]

--- a/secretpy/ciphers/scytale.py
+++ b/secretpy/ciphers/scytale.py
@@ -1,0 +1,109 @@
+#!/usr/bin/python
+# -*- encoding: utf-8 -*-
+
+
+class Scytale:
+    """
+    The Scytale Cipher
+    """
+
+    def __enc(self, text: str, key: int):
+        block_list = []
+        ans = ""
+        rows = 0
+
+        # Round up number of "rows"
+        # "ceil(len(text) / key" not possible due to compatibility to python 2)
+        if (len(text) % key) != 0:
+            rows = int((len(text) / key) + 1)
+        else:
+            rows = int(len(text) / key)
+
+        # split text into blocks (row by row)
+        for i in range(0, rows):
+            if ((i * key) + key) <= len(text):
+                block_list.append(text[(i * key):((i * key) + key)])
+            else:
+                block_list.append(text[(i * key):len(text)])
+
+        # read characters from blocks
+        for char in range(0, key):
+            for block in range(0, rows):
+                try:
+                    ans = ans + block_list[block][char]
+                except:
+                    break
+        return ans
+
+    def __dec(self, text: str, key: int):
+        block_list = []
+        ans = ""
+        rows = 0
+        additional_chars = len(text) % key
+        block_start = 0
+        block_end = 0
+
+        # Round up number of "rows" and "block_end"
+        # "ceil(len(text) / key" not possible due to compatibility to python 2)
+        if (len(text) % key) != 0:
+            rows = int((len(text) / key) + 1)
+            block_end = int((len(text) / key) + 1)
+        else:
+            rows = int(len(text) / key)
+            block_end = int(len(text) / key)
+
+        # split text into blocks (column by column)
+        for i in range(0, key):
+            # If scytale is fully occupied
+            if (rows * key) == len(text):
+                block_list.append(text[block_start:block_end])
+                block_start = block_start + rows
+                block_end = block_end + rows
+            # If scytale is NOT fully occupied (last row has empty places)
+            elif additional_chars > 1:
+                block_list.append(text[block_start:block_end])
+                additional_chars = additional_chars - 1
+                block_start = block_start + rows
+                block_end = block_end + rows
+            elif additional_chars == 1:
+                block_list.append(text[block_start:block_end])
+                additional_chars = additional_chars - 1
+                block_start = block_start + rows
+                block_end = block_end + (rows - 1)
+            elif additional_chars == 0:
+                block_list.append(text[block_start:block_end])
+                block_start = block_start + (rows - 1)
+                block_end = block_end + (rows - 1)
+
+        # read characters from blocks
+        for char in range(0, rows):
+            for block in range(0, key):
+                try:
+                    ans = ans + block_list[block][char]
+                except:
+                    break
+        return ans
+
+    def encrypt(self, text, key):
+        """
+        Encryption method
+        :param text: Text to encrypt
+        :param key: Encryption key - Number of windings
+        :type text: string
+        :type key: integer
+        :return: encrypted text
+        :rtype: string
+        """
+        return self.__enc(text, key)
+
+    def decrypt(self, text, key):
+        """
+        Decryption method
+        :param text: Text to decrypt
+        :param key: Decryption key - Number of windings
+        :type text: string
+        :type key: integer
+        :return: decrypted text
+        :rtype: string
+        """
+        return self.__dec(text, key)

--- a/secretpy/ciphers/scytale.py
+++ b/secretpy/ciphers/scytale.py
@@ -1,19 +1,22 @@
 #!/usr/bin/python
 # -*- encoding: utf-8 -*-
 
+import secretpy.alphabets as al
+
 
 class Scytale:
     """
     The Scytale Cipher
     """
+    __alphabet = al.ENGLISH
 
-    def __enc(self, text: str, key: int):
+    def __enc(self, text, key, alphabet):
         block_list = []
         ans = ""
         rows = 0
 
         # Round up number of "rows"
-        # "ceil(len(text) / key" not possible due to compatibility to python 2)
+        # "ceil(len(text) / key" not possible due to compatibility to python 2
         if (len(text) % key) != 0:
             rows = int((len(text) / key) + 1)
         else:
@@ -35,7 +38,7 @@ class Scytale:
                     break
         return ans
 
-    def __dec(self, text: str, key: int):
+    def __dec(self, text, key, alphabet):
         block_list = []
         ans = ""
         rows = 0
@@ -44,7 +47,7 @@ class Scytale:
         block_end = 0
 
         # Round up number of "rows" and "block_end"
-        # "ceil(len(text) / key" not possible due to compatibility to python 2)
+        # "ceil(len(text) / key" not possible due to compatibility to python 2
         if (len(text) % key) != 0:
             rows = int((len(text) / key) + 1)
             block_end = int((len(text) / key) + 1)
@@ -84,26 +87,30 @@ class Scytale:
                     break
         return ans
 
-    def encrypt(self, text, key):
+    def encrypt(self, text, key, alphabet=None):
         """
         Encryption method
         :param text: Text to encrypt
         :param key: Encryption key - Number of windings
+        :param alphabet: Alphabet which will be used,
+                         if there is no a value, English is used
         :type text: string
         :type key: integer
         :return: encrypted text
         :rtype: string
         """
-        return self.__enc(text, key)
+        return self.__enc(text, key, alphabet)
 
-    def decrypt(self, text, key):
+    def decrypt(self, text, key, alphabet=None):
         """
         Decryption method
         :param text: Text to decrypt
         :param key: Decryption key - Number of windings
+        :param alphabet: Alphabet which will be used,
+                         if there is no a value, English is used
         :type text: string
         :type key: integer
         :return: decrypted text
         :rtype: string
         """
-        return self.__dec(text, key)
+        return self.__dec(text, key, alphabet)

--- a/tests/test_scytale.py
+++ b/tests/test_scytale.py
@@ -2,7 +2,7 @@
 # -*- encoding: utf-8 -*-
 
 
-from scytale import Scytale
+from secretpy import Scytale
 import unittest
 
 

--- a/tests/test_scytale.py
+++ b/tests/test_scytale.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+# -*- encoding: utf-8 -*-
+
+
+from scytale import Scytale
+import unittest
+
+
+class TestScytale(unittest.TestCase):
+
+    key = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+    plaintext = "Iamhurtverybadlyhelp"
+
+    ciphertext = ["Iamhurtverybadlyhelp",  # 1
+                  "Imuteyalhlahrvrbdyep",  # 2
+                  "Ihtraylauvydhpmreble",  # 3
+                  "Iueaharrdemtyllhvbyp",  # 4
+                  "Iryyatbhmvaehedlurlp",  # 5
+                  "Italavdpmelhryuyhrbe",  # 6
+                  "Ivlaeymrhhyeublraptd",  # 7
+                  "Ieharemylhbpuardtlvy",  # 8
+                  "Irlaypmbhaudrltyvhee",  # 9
+                  "Iyabmahdulrythveelrp"]  # 10
+
+    def test_encrypt(self):
+        for i, k in enumerate(self.key):
+            enc = Scytale().encrypt(self.plaintext, k)
+            self.assertEqual(enc, self.ciphertext[i])
+
+    def test_decrypt(self):
+        for i, k in enumerate(self.key):
+            dec = Scytale().decrypt(self.ciphertext[i], k)
+            self.assertEqual(dec, self.plaintext)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_scytale.py
+++ b/tests/test_scytale.py
@@ -3,10 +3,14 @@
 
 
 from secretpy import Scytale
+from secretpy import alphabets
 import unittest
 
 
 class TestScytale(unittest.TestCase):
+    alphabet = (
+        alphabets.ENGLISH
+    )
 
     key = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
@@ -24,13 +28,13 @@ class TestScytale(unittest.TestCase):
                   "Iyabmahdulrythveelrp"]  # 10
 
     def test_encrypt(self):
-        for i, k in enumerate(self.key):
-            enc = Scytale().encrypt(self.plaintext, k)
+        for i, key in enumerate(self.key):
+            enc = Scytale().encrypt(self.plaintext, key, self.alphabet)
             self.assertEqual(enc, self.ciphertext[i])
 
     def test_decrypt(self):
-        for i, k in enumerate(self.key):
-            dec = Scytale().decrypt(self.ciphertext[i], k)
+        for i, key in enumerate(self.key):
+            dec = Scytale().decrypt(self.ciphertext[i], key, self.alphabet)
             self.assertEqual(dec, self.plaintext)
 
 


### PR DESCRIPTION
I have rewritten the algorithm for the scytale cipher. Also I have created the "test_scytale.py" script and tested it.

I found different specifications of what the key is:
- My main tool for testing was [Cryptool Online](https://www.cryptool.org/en/cto/scytale) and it uses the number of windings as key
- the same for [Dcode.fr](https://www.dcode.fr/scytale-cipher)
- in contrast to [Dencode.com](https://dencode.com/en/cipher/scytale) which uses the number of chars per winding as key

I used the number of windings and have also specified this in the docstring. The algorithm should also be compatible with Python2. Alphabets are not necessary because it's solved purely via displacement.

But please review the code and test it.
Sorry for the waste of time because of the first script.

LuminousLizard